### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,7 @@
 name: Linters
 run-name: ${{ github.actor }} execute Linters 🚀
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/fazedordecodigo/PyFlunt/security/code-scanning/22](https://github.com/fazedordecodigo/PyFlunt/security/code-scanning/22)

The best fix is to add a `permissions` block either at the workflow root or under the specific job(s). Since there is only one job and no job name has been specified, it's preferable and clearer here to add the block at the workflow root. For typical linter workflows, only read access to repository contents is required, so the minimal permission set is:

```yaml
permissions:
  contents: read
```

To implement this, insert the block after the workflow `name` and (optionally) after `run-name` for YAML clarity, but before the `on` key. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
