### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Tests
 run-name: ${{ github.actor }} execute Tests
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/fazedordecodigo/PyFlunt/security/code-scanning/21](https://github.com/fazedordecodigo/PyFlunt/security/code-scanning/21)

To mitigate this issue, add an explicit `permissions:` block at the top-level of the workflow file—before the `jobs:` key. This ensures that all jobs and steps in the workflow receive only read access to repository contents via GITHUB_TOKEN, unless overridden elsewhere. This change adheres to the principle of least privilege, improves security posture, and satisfies CodeQL’s recommendation. Update `.github/workflows/tests.yml` to insert the block:

```yaml
permissions:
  contents: read
```

immediately after the `run-name` (line 2). No code functionality is affected, and no other imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
