### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/fazedordecodigo/PyFlunt/security/code-scanning/20](https://github.com/fazedordecodigo/PyFlunt/security/code-scanning/20)

The recommended fix is to add an explicit `permissions` block at the root level of the workflow (directly below the workflow `name:` or after `on:`) to restrict the GITHUB_TOKEN to only those permissions needed by the workflow. From reviewing the steps, this workflow only needs to read repo content and use secrets. None of the steps require writing to the repository or making PRs/issues. Therefore, setting

```yaml
permissions:
  contents: read
```

at the top (root) level will ensure all jobs have the minimal required access. This avoids any accidental privilege escalation while keeping the workflow fully functional.

Only the `.github/workflows/publish.yml` file needs editing, inserting the block just after `name:` (recommended), or after `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
