### PR TITLE
fix: retornar None em vez de string vazia quando padrão não encontrad…

### DIFF
--- a/flunt/localization/flunt_regex_patterns.py
+++ b/flunt/localization/flunt_regex_patterns.py
@@ -20,9 +20,9 @@ REGEX_PATTERNS = {
 }
 
 
-def get_pattern(name: str) -> str | Pattern[str]:
+def get_pattern(name: str) -> str | Pattern[str] | None:
     """Retrieve a regex pattern by its name."""
     value = REGEX_PATTERNS.get(name)
     if value is None:
-        return ""
+        return None
     return value

--- a/tests/localization/test_flunt_regex_patterns.py
+++ b/tests/localization/test_flunt_regex_patterns.py
@@ -100,6 +100,12 @@ def test_should_identify_letters_and_numbers(value: str, expect: bool) -> None:
     assert isinstance(result, re.Match) is expect
 
 
+def test_should_return_none_for_unknown_pattern() -> None:
+    """Test that get_pattern returns None for an unknown pattern name."""
+    result = get_pattern("non_existent_pattern")
+    assert result is None
+
+
 @pytest.mark.parametrize(
     ("value", "expect"),
     [


### PR DESCRIPTION
## Descrição
Corrige o bug onde a função `get_pattern()` retornava uma string vazia (`""`) em vez de `None` quando um padrão de regex não era encontrado no dicionário `REGEX_PATTERNS`. Este comportamento causava validações falso-positivas, pois uma string vazia pode fazer match com certos padrões regex, quando deveria retornar `None` para indicar que o padrão não existe.

## Mudanças Propostas

- Alterado `get_pattern()` em `flunt/localization/flunt_regex_patterns.py` para retornar `None` quando padrão não existe
- Atualizado tipo de retorno da função de `str | Pattern[str]` para `str | Pattern[str] | None`
- Adicionado teste `test_should_return_none_for_unknown_pattern` para validar comportamento com padrão inexistente
- Garante que validações falhem corretamente quando um padrão não está registrado, evitando falsos positivos

## Checklist de Revisão

- [x] Eu li o [Contributing.md](https://github.com/fazedordecodigo/pyflunt/blob/main/CONTRIBUTING.md)
- [x] Os testes foram adicionados ou atualizados para refletir as mudanças (se aplicável).
- [ ] Foi adicionada uma entrada no changelog / Meu PR não necessita de uma nova entrada no changelog.
- [ ] A [documentação](https://github.com/fazedordecodigo/pyflunt/blob/main/README.md) em português foi atualizada ou criada, se necessário.
- [ ] Se feita a documentação, a atualização do [arquivo em inglês](https://github.com/fazedordecodigo/pyflunt/blob/main/README_EN.md).
- [x] Eu documentei as minhas mudanças no código, adicionando docstrings e comentários. [Instruções](https://github.com/fazedordecodigo/pyflunt/blob/main/CONTRIBUTING.md#8-fa%C3%A7a-as-suas-altera%C3%A7%C3%B5es)
- [x] O código segue as diretrizes de estilo e padrões de codificação do projeto.
- [x] Todos os testes passam. [Instruções](https://github.com/fazedordecodigo/pyflunt/blob/main/CONTRIBUTING.md#testes)
- [x] O Pull Request foi testado localmente. [Instruções](https://github.com/fazedordecodigo/pyflunt/blob/main/CONTRIBUTING.md#7-execute-o-pyflunt-localmente)
- [x] Não há conflitos de mesclagem.

## Comentários Adicionais (opcional)

Este fix é importante para garantir a integridade das validações. O código existente que usa `get_pattern()` já está preparado para lidar corretamente com `None`, conforme verificado em:
- `email_validation_contract.py`
- `credit_card_validation_contract.py`
- `url_validation_contract.py`

Todos esses arquivos já possuem verificações `if pattern is None:` nas funções helper com cache, então a mudança é totalmente retrocompatível e não quebra nenhuma funcionalidade existente.

## Issue Relacionada

Closes #191